### PR TITLE
[TIDOC-2058] Updated call to jsduck to load @editurl tag library.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -219,7 +219,7 @@ else
     TEMPLATE=${JSDUCK}/${DEBUG_TEMPLATE}
 fi
 
-ruby ${JSDUCK}/bin/jsduck --template ${TEMPLATE} $seo --output $outdir --title "$title" --config $config $alloyDirs --meta-tags ${JSDUCK}/lib/jsduck/tag/editurl.rb 
+ruby ${JSDUCK}/bin/jsduck --template ${TEMPLATE} $seo --output $outdir --title "$title" --config $config $alloyDirs 
 
 # TIDOC-1327 Fix server errors
 cp -r "$guidesdir/images/icons" "$outdir/resources/images/."

--- a/deploy.sh
+++ b/deploy.sh
@@ -219,7 +219,7 @@ else
     TEMPLATE=${JSDUCK}/${DEBUG_TEMPLATE}
 fi
 
-ruby ${JSDUCK}/bin/jsduck --template ${TEMPLATE} $seo --output $outdir --title "$title" --config $config $alloyDirs 
+ruby ${JSDUCK}/bin/jsduck --template ${TEMPLATE} $seo --output $outdir --title "$title" --config $config $alloyDirs --meta-tags ${JSDUCK}/lib/jsduck/tag/editurl.rb 
 
 # TIDOC-1327 Fix server errors
 cp -r "$guidesdir/images/icons" "$outdir/resources/images/."

--- a/meta/EditUrlTag.rb
+++ b/meta/EditUrlTag.rb
@@ -1,0 +1,14 @@
+require "jsduck/meta_tag"
+
+class EditURLTag < JsDuck::MetaTag
+  def initialize
+    # This defines the name of the @tag
+    @name = "editurl"
+    @key = :editurl
+  end
+
+  def to_value(contents)
+    contents[0]
+  end
+
+end


### PR DESCRIPTION
## Verification

* Requires changes from https://github.com/appcelerator/titanium_mobile/pull/6609
* GitHub account -- To test the same workflow external users will experience, you need to be signed into GitHub using an alternate account (not the one you use for Appc work).

## Steps
1. In addition to this PR, merge the following:
* https://github.com/appcelerator/jsduck/pull/57 (Updates JSDuck app template to include 'Edit' button)
* https://github.com/appcelerator/alloy/pull/659 ('Manually' adds @editurl to the dozen or so Ally doc files.)
2. Build Titanium and Platform docs for production.
3. View random API docs of different types (Titanium, Alloy, module, Tizen) and verify that each class (with some exceptions*) displays an "Edit" button at the top of the page.
4. Click Edit button and verify that it opens the expected page (see https://wiki.appcelerator.org/display/~tstatler/API+edit+page+flow).

*Exceptions are modules in private repos, namely, ti.geofence, apm, and appcelerator.https. Verify that these pages do not have an Edit button.
