### PR TITLE
[TIDOC-2112] Alloy add-on docs to include Github edit urls

### DIFF
--- a/add-ons/alloy.js
+++ b/add-ons/alloy.js
@@ -1,0 +1,71 @@
+// "Mix-in" for Alloy API docs to include GitHub edit URLs (TIDOC-2058).
+
+/**
+ * @class Alloy.Collections
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/collection.js 
+*/
+
+/**
+ * @class Alloy.Controller
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/lib/alloy/controllers/BaseController.js
+*/
+
+/**
+ * @class Alloy.Controller.UI
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/controller.js
+*/
+
+/**
+ * @class Alloy.builtins.animation
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/animation.js
+*/
+
+/**
+ * @class Alloy.builtins.dialogs
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/dialogs.js  
+*/
+
+/**
+ * @class Alloy.builtins.measurement
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/measurement.js
+ */
+
+/**
+ * @class Alloy.builtins.sha1
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/sha1.js
+*/
+
+/**
+ * @class Alloy.builtins.social
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/social.js
+*/
+
+/**
+ * @class Alloy.builtins.string
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/builtins/string.js
+*/
+
+/**
+ * @class Alloy.builtins.moment
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/moment.js
+*/
+
+/**
+ * @class Alloy.builtins
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/builtins.js
+*/
+
+/**
+ * @class Alloy
+ * @editurl https://github.com/appcelerator/alloy/edit/master/Alloy/lib/alloy.js
+*/
+
+/**
+ * @class Alloy.Models
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/model.js
+*/
+
+/**
+ * @class Alloy.Widget
+ * @editurl https://github.com/appcelerator/alloy/edit/master/docs/apidoc/widgets.js
+*/

--- a/deploy.sh
+++ b/deploy.sh
@@ -128,7 +128,7 @@ if [ ! "$ALLOY" ]; then
 fi
 
 if [ $include_alloy ]; then
-    alloyDirs="${ALLOY}/Alloy/lib ${ALLOY}/docs/apidoc
+    alloyDirs="${ALLOY}/Alloy/lib ${ALLOY}/docs/apidoc ${DOCTOOLS}/add-ons
                $(find $ALLOY/Alloy/builtins -maxdepth 1 -type f ! -name moment.js)"
 fi
 


### PR DESCRIPTION
This PR adds a folder with a JS file that provides the edit URLs for each public Alloy class. JSDuck auto-magically merges this with the core Alloy docs. This folder is added to the ```$alloyDirs``` script variable. I submitted a PR to revert the merged changes to the Alloy repo.

**To test**:

1. Run ```sh deploy.sh -o alloy```
2. Open "dist/titanium/3.0/index.html".
3. Click on various Alloy API docs and verify that there's an "Edit" button that opens the expected page.