### PR TITLE
[TIDOC-1893] URL decode external links on wiki pages.

### DIFF
--- a/guides_parser.py
+++ b/guides_parser.py
@@ -135,6 +135,7 @@ def node2obj(node):
 			else:
 				# open external links in new windows/tabs
 				tag['target'] = '_blank'
+				tag['href'] = urllib.unquote(href)
 				pass
 		# otherwise, we're looking at an internal guides link.
 		else:


### PR DESCRIPTION
The Dashboard 3.0.1 latest release notes have a link to a Dashboard page which is getting URL encoded. This adds URL decoding to the hrefs for all external URLs.

#### To verify:

1. Export latest Platform docs from Confluence.
2. Run build_platform.sh.
3. Open platform/latest/ and click link to 3.0.1 release notes.
4. In *Improvements and Changes* click link to "Download Center" (fourth bullet point).
5. Verify that link opens the Downloads page on Dashboard.

(To see original bug, build platform docs with doctools master, and click link to see it 404 on Dashboard.)