### PR TITLE
[TIDOC-2122] Pull docs from new repo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -133,19 +133,11 @@ if [ $include_alloy ]; then
 fi
 
 if [ $include_modules ]; then
-    if [ ! "$TI_MODULES" ]; then
-        if [ "$TI_ROOT" ]; then
-            TI_MODULES=${TI_ROOT}/titanium_modules
-        else
-            echo "No titanium_modules dir \$TI_MODULES and \$TI_ROOT not defined. Exiting."
-            exit 1
-        fi
-    fi
     if [ ! "$APPC_MODULES" ]; then
         if [ "$TI_ROOT" ]; then
             APPC_MODULES=${TI_ROOT}/appc_modules
         else
-            echo "No titanium_modules dir \$TI_MODULES and \$TI_ROOT not defined. Exiting."
+            echo "No appc_modules dir \$APPC_MODULES and \$TI_ROOT not defined. Exiting."
             exit 1
         fi
     fi
@@ -159,7 +151,7 @@ if [ $include_modules ]; then
     fi
     module_dirs="$APPC_MODULES/ti.map/apidoc $APPC_MODULES/ti.facebook/apidoc
                  $APPC_MODULES/ti.nfc/apidoc $APPC_MODULES/ti.newsstand/apidoc $TIZEN_MODULE
-                 $APPC_MODULES/ti.coremotion/apidoc $TI_MODULES/urlSession/apidoc
+                 $APPC_MODULES/ti.coremotion/apidoc $APPC_MODULES/ti.urlsession/apidoc
                  $APPC_MODULES/ti.touchid/apidoc"
 
     if [ $addon_guidesdir ]; then

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -11,12 +11,13 @@ CORE_MOTION_DIR=$TI_ROOT/appc_modules/ti.coremotion
 FB_DIR=$TI_ROOT/appc_modules/ti.facebook
 GEOFENCE_DIR=$TI_ROOT/appc_modules/ti.geofence
 HTTPS_DIR=$TI_ROOT/appc_modules/appcelerator.https
-MOD_DIR=$TI_ROOT/titanium_modules
 MAP_DIR=$TI_ROOT/appc_modules/ti.map
 NFC_DIR=$TI_ROOT/appc_modules/ti.nfc
 NEWSSTAND_DIR=$TI_ROOT/appc_modules/ti.newsstand
 TIZEN_DIR=$TI_ROOT/titanium_mobile_tizen
 TOUCHID_DIR=$TI_ROOT/appc_modules/ti.touchid
+URL_DIR=$TI_ROOT/appc_modules/ti.urlsession
+
 
 ## Error handling
 fail_on_error() {
@@ -51,7 +52,6 @@ function repo_update {
 repo_update jsduck $JSDUCK_DIR upstream master
 repo_update titanium_mobile $TI_DIR upstream 3_5_X
 repo_update alloy $ALLOY_DIR upstream 1_5_X
-repo_update titanium_modules $MOD_DIR origin master
 repo_update com.appcelerator.apm $APM_DIR origin master
 repo_update ti.coremotione $CORE_MOTION_DIR upstream master
 repo_update ti.facebook $FB_DIR upstream master
@@ -62,5 +62,6 @@ repo_update ti.nfc $NFC_DIR origin master
 repo_update ti.newsstand $NEWSSTAND_DIR origin master
 repo_update titanium_mobile_tizen $TIZEN_DIR origin 3_2_X
 repo_update ti.touchid $TOUCHID_DIR origin master
+repo_update ti.urlsession $URL_DIR origin master
 
 echo "Repo updates completed"

--- a/repo_update_jenkins.sh
+++ b/repo_update_jenkins.sh
@@ -12,12 +12,12 @@ CORE_MOTION_DIR=$TI_ROOT/appc_modules/ti.coremotion
 FB_DIR=$TI_ROOT/appc_modules/ti.facebook
 GEOFENCE_DIR=$TI_ROOT/appc_modules/ti.geofence
 HTTPS_DIR=$TI_ROOT/appc_modules/appcelerator.https
-MOD_DIR=$TI_ROOT/titanium_modules
 MAP_DIR=$TI_ROOT/appc_modules/ti.map
 NFC_DIR=$TI_ROOT/appc_modules/ti.nfc
 NEWSSTAND_DIR=$TI_ROOT/appc_modules/ti.newsstand
 TIZEN_DIR=$TI_ROOT/titanium_mobile_tizen
 TOUCHID_DIR=$TI_ROOT/appc_modules/ti.touchid
+URL_DIR=$TI_ROOT/appc_modules/ti.urlsession
 
 ## Error handling
 fail_on_error() {
@@ -66,13 +66,12 @@ fi
 repo_update jsduck $JSDUCK_DIR origin master appcelerator
 repo_update titanium_mobile $TI_DIR origin master appcelerator
 repo_update alloy $ALLOY_DIR origin master appcelerator
-repo_update titanium_modules $MOD_DIR origin master appcelerator
 repo_update ti.coremotion $CORE_MOTION_DIR origin master appcelerator-modules
 repo_update ti.facebook $FB_DIR origin master appcelerator-modules
 repo_update ti.map $MAP_DIR origin master appcelerator-modules
 repo_update ti.nfc $NFC_DIR origin master appcelerator-modules
 repo_update ti.newsstand $NEWSSTAND_DIR origin master appcelerator-modules
 repo_update ti.touchid $TOUCHID_DIR origin master appcelerator-modules
-repo_update titanium_mobile_tizen $TIZEN_DIR origin 3_2_X appcelerator
+repo_update ti.urlsession $TOUCHID_DIR origin master appcelerator-modules
 
 echo "Repo updates completed"


### PR DESCRIPTION
Clone the ti.urlsession repo in to the $TI_ROOT/appc_modules directory:

`git clone https://github.com/appcelerator-modules/ti.urlsession.git`

Then build the docs with the modules

`bash deploy.sh -o modules`

Should be the same as the current docs.