### PR TITLE
Added version specific pulldowns and jsduck

### DIFF
--- a/updateNPMModules.sh
+++ b/updateNPMModules.sh
@@ -13,30 +13,48 @@
 ## https://wiki.appcelerator.org/x/qdPBAg						   						##
 ##########################################################################################
 
+SECONDS=0
+
 bold=$(tput bold)
 normal=$(tput sgr0)
-mobile=( js-yaml pagedown ) ## npm modules necessary for titanium_mobile directory
-doctools=( cheerio xml2js glob shelljs ) ## npm modules necessary for doctools directory
+mobile=( js-yaml@3.6.1 pagedown@1.1.0 cheerio@0.22.0 xml2js@0.4.17) ## npm modules necessary for titanium_mobile directory
+doctools=( cheerio@0.19.0 pagedown@1.1.0 xml2js@0.4.17 html-entities@1.1.3 glob@7.1.0 shelljs@0.7.4 ) ## npm modules necessary for doctools directory
+jsduck=( html-entities@1.2.0 ) ## npm modules necessary for jsduck
 
 getNPMs () { ## check to see if a NPM modules is missing and install it if it is missing
 	if [ $1 == "titanium_mobile" ]; then
 		echo "Reviewing titanium_mobile for ${bold}$2${normal}"
 		cd $TI_ROOT/titanium_mobile/apidoc
-		if [ ! -d $TI_ROOT/titanium_mobile/node_modules/$2 ]; then 
-			echo "Missing $2 npm. Installing it now.\n"
+		module="$(echo $2|cut -d'@' -f 1)" ## js-yaml@3.6.1 becomes js-yaml
+		if [ ! -d $TI_ROOT/titanium_mobile/node_modules/$module ]; then 
+			echo "Missing $module npm. Installing it now.\n"
 			cd $TI_ROOT/titanium_mobile
 			npm install $2
 		else 
-			echo "found $2 in $TI_ROOT/titanium_mobile/node_modules/$2; skipping the installer.\n";
+			echo "found $module in $TI_ROOT/titanium_mobile/node_modules/$module; skipping the installer.\n";
 		fi
 	elif [ $1 == "doctools" ]; then
 		echo "Reviewing doctools for ${bold}$2${normal}"		
 		cd $TI_ROOT/doctools
-			if [ ! -d $TI_ROOT/doctools/node_modules/$2 ]; then 
-			echo "Missing $2 npm. Installing it now.\n"
+		module="$(echo $2|cut -d'@' -f 1)" ## cheerio@0.19.0 becomes cheerio
+		if [ ! -d $TI_ROOT/doctools/node_modules/$module ]; then 
+			echo "Missing $module npm. Installing it now.\n"
 			npm install $2
 		else 
-			echo "found $2 in $TI_ROOT/doctools/node_modules/$2; skipping the installer.\n";
+			echo "found $2 in $TI_ROOT/doctools/node_modules/$module; skipping the installer.\n";
+		fi
+	elif [ $1 == "jsduck" ]; then
+		echo "Reviewing jsduck for ${bold}$2${normal}"		
+		cd $TI_ROOT/jsduck
+		if [ ! -d $TI_ROOT/jsduck/node_modules ]; then
+			mkdir node_modules
+		fi
+		module="$(echo $2|cut -d'@' -f 1)" ## html-entities@1.2.0 becomes html-entities
+		if [ ! -d $TI_ROOT/jsduck/node_modules/$module ]; then 
+			echo "Missing $module npm. Installing it now.\n"
+			npm install $2
+		else 
+			echo "found $2 in $TI_ROOT/jsduck/node_modules/$module; skipping the installer.\n";
 		fi
 	fi
 }
@@ -50,3 +68,10 @@ for i in "${doctools[@]}"
 do
 	getNPMs doctools $i ## install missing npm modules in the doctools directory
 done
+for i in "${jsduck[@]}"
+do
+	getNPMs jsduck $i ## install missing npm modules in the doctools directory
+done
+
+duration=$SECONDS
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."


### PR DESCRIPTION
Instead of pulling down the latest version of each npm module, I set
the arrays to include a version specific value for each module. The
script then creates a new variable by stripping out the version info
and then checks to see if the module is installed. If it isn’t, then
the script will install the module by a specific version per module.
I also added a function call for jsduck directory specific modules.
Finally, I added a timer